### PR TITLE
Fix:evidenceView 좁은 사이드바에서 Suggested/Raw Evidence 액션 버튼 이탈 방지

### DIFF
--- a/src/views/evidenceView.ts
+++ b/src/views/evidenceView.ts
@@ -103,8 +103,20 @@ export class EvidenceViewProvider implements vscode.WebviewViewProvider {
   <style>
     body { color: var(--vscode-foreground); background: var(--vscode-sideBar-background); padding: 10px; }
     .muted { color: var(--vscode-descriptionForeground); font-size: 12px; }
-    .row { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+    .row { display: flex; justify-content: space-between; align-items: center; gap: 8px; min-width: 0; }
+    .evidenceRow { align-items: flex-start; flex-wrap: wrap; }
+    .evidenceMain { flex: 1 1 180px; min-width: 0; }
+    .evidenceActions { display: flex; gap: 6px; flex-wrap: wrap; justify-content: flex-end; }
+    .evidenceMain .title, .evidenceMain .meta { overflow-wrap: anywhere; }
+    .suggestionRow { align-items: flex-start; flex-wrap: wrap; }
+    .suggestionTitle { flex: 1 1 180px; min-width: 0; overflow-wrap: anywhere; }
     .toolbar { display: flex; gap: 8px; flex-wrap: wrap; margin: 10px 0 14px; }
+    .toolbar button {
+      flex: 1 1 150px;
+      min-width: 0;
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
     button {
       color: var(--vscode-button-foreground);
       background: var(--vscode-button-background);
@@ -205,14 +217,16 @@ export class EvidenceViewProvider implements vscode.WebviewViewProvider {
         card.className = 'card';
 
         const top = document.createElement('div');
-        top.className = 'row';
+        top.className = 'row evidenceRow';
 
         const left = document.createElement('div');
+        left.className = 'evidenceMain';
         left.innerHTML = '<div class="title"></div><div class="meta"></div>';
         left.querySelector('.title').textContent = it.title || '(no title)';
         left.querySelector('.meta').textContent = (it.type || 'evidence') + ' • ' + (it.ref || '');
 
         const right = document.createElement('div');
+        right.className = 'evidenceActions';
         const editBtn = document.createElement('button');
         editBtn.className = 'secondary';
         editBtn.textContent = 'Edit why';
@@ -313,9 +327,9 @@ export class EvidenceViewProvider implements vscode.WebviewViewProvider {
         card.className = 'card';
 
         const top = document.createElement('div');
-        top.className = 'row';
+        top.className = 'row suggestionRow';
         const title = document.createElement('div');
-        title.className = 'title';
+        title.className = 'title suggestionTitle';
         title.textContent = it.title || 'Suggested raw evidence';
         top.appendChild(title);
 


### PR DESCRIPTION
### 문제 요약 
사이드바 폭이 작아질 때 Suggested Raw Evidence와 Raw Evidence 카드 헤더가 flex 한 줄 배치로 유지되면서, 액션 버튼(Add Selection, Edit why, Remove)이 카드 영역 밖으로 밀려 UI가 이탈

### 변경 사항
- 공통 row 컨테이너의 축소 허용
   - .row에 min-width: 0 추가 (evidenceView.ts (line 106))
- Raw Evidence 카드 전용 반응형 레이아웃 추가 (evidenceView.ts line 107-110) 
- Raw Evidence 렌더링에 전용 클래스 적용 (evidenceView.ts line 220, 223, 229)
- Suggested Raw Evidence 카드 전용 반응형 레이아웃 추가 (evidenceView.ts line 111-112)
- Suggested Raw Evidence 렌더링에 전용 클래스 적용 (Add Selection 버튼 이탈 방지) (evidenceView.ts line 330-332) 
- 상단 툴바 버튼도 폭 축소 시 줄바꿈 가능하도록 보강 (evidenceView.ts line 114-118)